### PR TITLE
Added checks for zip and git near the start of release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,9 +5,15 @@ DEST_DIR="$1"
 [ "$DEST_DIR" == "" ] && echo "No destination directory specified, assuming current directory" && DEST_DIR="$THIS_DIR"
 VERSION=$(<"$THIS_DIR/src/.jcd-new/VERSION")
 ZIP_FILE_NAME="$DEST_DIR/jcd-new_v$VERSION.zip"
-echo "creating zip file $ZIP_FILE_NAME"
-pushd "$THIS_DIR/src"
 
+zip_ver=$(zip -v > /dev/null)
+echo "zip detected."
+
+git_ver=$(git --version)
+echo "$git_ver detected."
+
+pushd "$THIS_DIR/src"
+echo "creating zip file $ZIP_FILE_NAME"
 zip -r "$ZIP_FILE_NAME" .
 
 echo "Adding/resetting version tag v$VERSION"


### PR DESCRIPTION
## Description
Added checks for zip and git near the start of release.sh
Fixes #5 
Fixes #6 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [X] Manually executed in an environment without zip and ensured an error message displayed
- [X] Manually executed in an environment without git and ensured an error message displayed
- [X] Manually executed in an environment with both and ensured the zip file and tag were created


**Test Configurations**:
* OS: Windows 10, git-bash (with MSYS2 version of zip copied into the PATH of git-bash)
* OS: Windows 10, git-bash without zip in the PATH
* OS: Debian 11, WSL2, bash with zip and git installed
* OS: Debian 11, WSL2, bash with git missing
* OS: Debian 11, WSL2, bash with zip missing

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
