### PR TITLE
Updated install.sh to warn if destination directory not in PATH

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -15,10 +15,11 @@ DEST_DIR="$1"
 case :$PATH: # notice colons around the value
   in *:$DEST_DIR:*) ;; # do nothing, it's there
      *) # warn the user that the destination isn't in the PATH
-        echo "WARNING: $DEST_DIR not in the PATH" >&2
+        echo "WARNING: '$DEST_DIR' is not currently in your PATH."
+        echo "You will need to add it to your PATH before being able to execute the scripts."
         while true; do
           # Prompt to continue or exit. Only accept Y/N/Yes/No (enter is considered N) as answers.
-          read -r -p "Do you wish to continue [yN]?" yn
+          read -r -p "Do you want to continue [yN]?" yn
           case $yn in
               # Yes specified. Break from the loop.
               [Yy]|[Yy][Ee][Ss]) echo "'Yes' selected. Proceeding with the installation to '$DEST_DIR'" && break;;

--- a/src/install.sh
+++ b/src/install.sh
@@ -1,12 +1,46 @@
 #!/bin/bash
 set -e
+
+# get the directory this script is executing from.
 export THIS_DIR=$(dirname $(readlink -f $0))
 DEST_DIR="$1"
+
+# check if the user specified a destination path. If not notify the user that ~/bin will be used.
 [ "$DEST_DIR" == "" ] && echo "No directory specified, assuming ~/bin" && DEST_DIR=~/bin
+
+# check if the destination exists, warn then exit with an error code if not.
 [ ! -d $DEST_DIR ] && echo "Directory $DEST_DIR DOES NOT exist. Aborting." && exit 1
 
-#TODO: Add a check and warning about not installing to a location in the PATH, but proceed anyways.
+# check if the destination directory is in the PATH
+case :$PATH: # notice colons around the value
+  in *:$DEST_DIR:*) ;; # do nothing, it's there
+     *) # warn the user that the destination isn't in the PATH
+        echo "WARNING: $DEST_DIR not in the PATH" >&2
+        while true; do
+          # Prompt to continue or exit. Only accept Y/N/Yes/No (enter is considered N) as answers.
+          read -r -p "Do you wish to continue [yN]?" yn
+          case $yn in
+              # Yes specified. Break from the loop.
+              [Yy]|[Yy][Ee][Ss]) echo "'Yes' selected. Proceeding with the installation to '$DEST_DIR'" && break;;
 
+              # "No" or ENTER specified. Exit.
+              [Nn]|[Nn][Oo]|"") echo "'No' selected. Exiting." && exit 0;;
+
+              # complain to the user.
+              *) echo "Please answer yes or no.";;
+          esac
+        done
+        ;;
+esac
+
+# copy the supporting scripts over.
 cp -TRv "$THIS_DIR/.jcd-new/" "$DEST_DIR/.jcd-new/"
+
+# copy the main entrypoint over.
 cp "$THIS_DIR/jcd-new" "$DEST_DIR"
+
+# make the main entrypoint executable.
 chmod u+x "$DEST_DIR/jcd-new"
+
+# Announce success
+echo "jcd-new successfully installed."


### PR DESCRIPTION
## Description

Updated install.sh to warn if destination directory not in PATH

Fixes #10 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] install.sh was executed specifying a directory not in the path and the prompting logic was exercised to ensure only ENTER (treated as N), Y, N, yes, or no, would be accepted (case insensitive).
- [X] install.sh was executed specifying directory in the PATH and the output was inspected to ensure the install proceeded without pause.

**Test Configuration**:
* OS: Windows 10 with git bash
* Debian 11 on WSL2

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
