### PR TITLE
release.sh now zips to correct relative path

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,12 +5,14 @@ set -e
 # get the location where this script is running from.
 # shellcheck disable=SC2046
 THIS_DIR=$(dirname $(readlink -f "$0"))
-
-# resolve the full destination path.
-DEST_DIR=$(realpath "$1")
+export THIS_DIR
 
 # if no destination specified notify the user the current directory will be used.
+DEST_DIR="$1"
 [ "$DEST_DIR" == "" ] && echo "No destination directory specified, assuming current directory" && DEST_DIR="$THIS_DIR"
+
+# resolve the full destination path.
+DEST_DIR=$(realpath "$DEST_DIR")
 
 # read the current app version.
 VERSION=$(<"$THIS_DIR/src/.jcd-new/VERSION")

--- a/release.sh
+++ b/release.sh
@@ -1,23 +1,45 @@
 #!/bin/bash
+# abort on any error.
 set -e
-export THIS_DIR=$(dirname $(readlink -f "$0"))
-DEST_DIR="$1"
+
+# get the location where this script is running from.
+# shellcheck disable=SC2046
+THIS_DIR=$(dirname $(readlink -f "$0"))
+
+# resolve the full destination path.
+DEST_DIR=$(realpath "$1")
+
+# if no destination specified notify the user the current directory will be used.
 [ "$DEST_DIR" == "" ] && echo "No destination directory specified, assuming current directory" && DEST_DIR="$THIS_DIR"
+
+# read the current app version.
 VERSION=$(<"$THIS_DIR/src/.jcd-new/VERSION")
+
+# compose the target zip file name
 ZIP_FILE_NAME="$DEST_DIR/jcd-new_v$VERSION.zip"
 
+# check that zip is actually installed. (intentionally unused results)
+# shellcheck disable=SC2034
 zip_ver=$(zip -v > /dev/null)
 echo "zip detected."
 
+# check that git is actually installed.
 git_ver=$(git --version)
 echo "$git_ver detected."
 
+# move into the source directory (that's what we zip up!)
 pushd "$THIS_DIR/src"
+
+# create the zip file.
 echo "creating zip file $ZIP_FILE_NAME"
 zip -r "$ZIP_FILE_NAME" .
 
+# apply the tag locally to git.
+# this script doesn't push the tag as a safety mechanism.
 echo "Adding/resetting version tag v$VERSION"
 git tag -f "v$VERSION"
 
+# warn the user that they'll need to manually push the tag
 echo "You will need to manually upload the release and push the version tag to GitHub."
+echo "       git push origin v$VERSION"
 popd

--- a/release.sh
+++ b/release.sh
@@ -3,9 +3,7 @@
 set -e
 
 # get the location where this script is running from.
-# shellcheck disable=SC2046
 THIS_DIR=$(dirname $(readlink -f "$0"))
-export THIS_DIR
 
 # if no destination specified notify the user the current directory will be used.
 DEST_DIR="$1"


### PR DESCRIPTION
## Description
Fixed an issue where `release.sh` would inadvertently zip to the current folder when specifying the parent folder. This was resolved by calling into "realpath" to resolve the full path of the destination.

Fixes #16 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested on Linux (WSL2) and Windows (git-bash) from within the git repository directory.

- [X] Execute `release.sh` (no parameters) and verify the zip is output to the current directory.
- [X] Execute `release.sh .` verify the zip is output to the current directory.
- [X] Execute `release.sh ..` verify the zip is output to the parent directory.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
