### PR TITLE
Refactored portions of jcd-new-classlib functionality into shared library functions

### DIFF
--- a/src/.jcd-new/VERSION
+++ b/src/.jcd-new/VERSION
@@ -1,1 +1,1 @@
-v0.0.4-alpha
+v0.0.5-alpha

--- a/src/.jcd-new/jcd-new-classlib
+++ b/src/.jcd-new/jcd-new-classlib
@@ -48,7 +48,7 @@ abort_on_missing_variable GITHUB_USER_NAME "Cannot process various GitHub integr
 
 #validate that $github has been set and the directory exists
 abort_on_missing_variable github
-if [ ! -d "$github" ]; then
+if [ ! -d "$(realpath -qm "$github")" ]; then
   echo "ABORTING: \$github defined, but the directory it points to doesn't exist: $github"
   exit 1;
 fi

--- a/src/.jcd-new/jcd-new-classlib
+++ b/src/.jcd-new/jcd-new-classlib
@@ -121,13 +121,7 @@ popd
 echo "Performing initial build of $PROJECT_NAME to generate documentation stub."
 dotnet build
 
-git add .
-git add --renormalize .
-git commit -m ".NET Standard $NETSTANDARD_VERSION project created with jcd-new classlib"
-
-echo "Setting main branch name"
-git branch -M main
-
+perform_initial_commit_and_set_branch_name_to_main ".NET Standard $NETSTANDARD_VERSION project created with jcd-new classlib"
 if [ "$NO_GITHUB" == "1" ]
 then
   echo "--no-github specified. Skipping push to github."

--- a/src/.jcd-new/jcd-new-classlib
+++ b/src/.jcd-new/jcd-new-classlib
@@ -120,23 +120,17 @@ process_template "$JCD_NEW_TEMPLATES/classlib/Class1.cs.template" "Class1.cs"
 
 popd
 
-echo "Performing initial build of $PROJECT_NAME to generate documentation stub."
+echo "Performing initial build of $PROJECT_NAME to generate documentation stubs."
 dotnet build
 
 perform_initial_commit_and_set_branch_name_to_main ".NET Standard $NETSTANDARD_VERSION project created with jcd-new classlib"
+
 if [ "$NO_GITHUB" == "1" ]
 then
-  echo "--no-github specified. Skipping push to github."
-  popd
-  exit 0
+  echo "--no-github specified. Skipping GitHub repository creation and initial push."
+else
+  create_github_repo_and_push
 fi
-
-echo "Creating the github repository and pushing."
-# Create the github repo and do the initial push
-gh auth login --hostname github.com || true
-gh repo create "$GITHUB_USER_NAME/$PROJECT_NAME" --public --gitignore= --license= -y || true
-git remote add origin "https://github.com/$GITHUB_USER_NAME/$PROJECT_NAME.git"
-git push -u origin main || true
 
 # always pop the directory as a final step before exiting.
 popd

--- a/src/.jcd-new/jcd-new-classlib
+++ b/src/.jcd-new/jcd-new-classlib
@@ -48,7 +48,9 @@ abort_on_missing_variable GITHUB_USER_NAME "Cannot process various GitHub integr
 
 #validate that $github has been set and the directory exists
 abort_on_missing_variable github
-if [ ! -d "$(realpath -qm "$github")" ]; then
+#expand tilde to the contents of $HOME for maximum portability. (Debian 11 on WSL2 doesn't properly expand during the check below)
+export github="${github/#\~/$HOME}"
+if [ ! -d "$github" ]; then
   echo "ABORTING: \$github defined, but the directory it points to doesn't exist: $github"
   exit 1;
 fi

--- a/src/.jcd-new/jcd-new-classlib
+++ b/src/.jcd-new/jcd-new-classlib
@@ -1,6 +1,6 @@
 #!/bin/bash
-source "$JCD_NEW_LIBS/jcd-new.bashlib"
 set -e
+
 if [ $# -eq 0 ]; then
   echo "No arguments provided to jcd-new classlib. Displaying help."
   bash "$JCD_NEW_LIBS/jcd-new-help-classlib"
@@ -11,17 +11,17 @@ for i in $*; do
   case $i in
     -p=*|--project=*|--project-name=*)
       echo "found project name parameter"
-      PROJECT_NAME="${i#*=}"
+      export PROJECT_NAME="${i#*=}"
       shift # past argument=value
       ;;
     -ngh|--no-github)
       echo "found NO_GITHUB flag"
-      NO_GITHUB=1
+      export NO_GITHUB=1
       shift # past argument
       ;;
     -nsv=*|--netstandard-version=*)
       echo "found NETSTANDARD_VERSION parameter"
-      NETSTANDARD_VERSION="${i#*=}"
+      export NETSTANDARD_VERSION="${i#*=}"
       shift # past argument
       ;;
     --version)
@@ -36,137 +36,83 @@ for i in $*; do
   esac
 done
 
-if [ -z ${PROJECT_NAME+x} ]
-then
-    echo "No project name specified. Please use -p=, --project=, or --project-name= to specify the project name."
-    exit 1
-fi
+abort_on_missing_variable PROJECT_NAME "ABORTING: No project name specified. Please use -p=, --project=, or --project-name= to specify the project name."
 
-if [ -z ${NETSTANDARD_VERSION+x} ]
-then
-    echo ".NET Standard version not specified, defaulting to .NET Standard 2.1"
-    NETSTANDARD_VERSION=2.1
-fi
+validate_netstandard_version "$NETSTANDARD_VERSION"
 
-if [[ "$NETSTANDARD_VERSION" != @(1[.]0|1[.]1|1[.]2|1[.]3|1[.]4|1[.]5|1[.]6|2[.]0|2[.]1) ]]
-then
-  echo "$NETSTANDARD_VERSION is not a recognized/supported version of .NET Standard."
-  exit 1
-fi
+abort_on_missing_variable NETSTANDARD_VERSION
 
-if [ -z ${FULL_NAME+x} ]
-then
-    echo "\$FULL_NAME not specified in the environment. Cannot process $JCD_NEW_TEMPLATES/LICENSE.template without it. Aborting."
-    exit 1
-fi
+abort_on_missing_variable FULL_NAME "Cannot process $JCD_NEW_TEMPLATES/LICENSE.template without it." true
 
-if [ -z ${GITHUB_USER_NAME+x} ]
-then
-    echo "\$GITHUB_USER_NAME not specified in the environment. Cannot process $JCD_NEW_TEMPLATES/classlib/README.md.template without it. Aborting."
-    exit 1
-fi
+abort_on_missing_variable GITHUB_USER_NAME "Cannot process various GitHub integrations without it." true
 
 #validate that $github has been set and the directory exists
-if [ -z ${github+x} ]
-then
-  echo "\$github variable not set. Aborting."
+abort_on_missing_variable github
+if [ ! -d "$github" ]; then
+  echo "ABORTING: \$github defined, but the directory it points to doesn't exist: $github"
   exit 1;
 fi
 
-# validate that the GITHUB_TOKEN environment variable is set.
-if [ -z ${GITHUB_TOKEN+x} ]
-then
-  echo "\$GITHUB_TOKEN variable not set. Aborting."
-  exit 1
-fi
-# validate GITHUB_USER_NAME is set
-if [ -z ${GITHUB_USER_NAME+x} ]
-then
-  echo "\$GITHUB_USER_NAME variable not set."
-  exit 1
-fi
+abort_on_missing_variable GITHUB_TOKEN
 
-# validate that the gh tool is installed
-gh_ver=$(gh --version)
-echo "gh version $gh_ver detected."
+abort_on_missing_variable GITHUB_USER_NAME
 
-# validate that the dotnet command line is installed
-dotnet_ver=$(dotnet --version)
-echo "dotnet version $dotnet_ver detected."
+abort_on_missing_gh
+
+abort_on_missing_dotnet
 
 # capture some data
-YEAR=$(date +'%Y')
+export YEAR=$(date +'%Y')
 
 pushd "$github"
 
 #Verify the project doesn't already exist
 if [ -d "./$PROJECT_NAME" ]
-  then echo "Cannot create new project: folder already exists."
+  then echo "Cannot create new project: directory already exists."
   exit 1;
 fi
 
-echo Creating project "$PROJECT_NAME"
-dotnet new sln -o "$PROJECT_NAME"
-cd "./$PROJECT_NAME"
-echo "Initializing git repository"
-git init
+create_sln "$PROJECT_NAME"
+# now move into the newly created solution folder. This will be out repository root too.
+cd "./$PROJECT_NAME" #TODO: figure out why I didn't do a pushd/popd pair for this directory...
 
-echo "Adding empty .gitignore"
-touch .gitignore
+# initialize the git repository.
+init_git
 
-
-curl https://raw.githubusercontent.com/github/gitignore/master/Global/JetBrains.gitignore >> .gitignore
-curl https://raw.githubusercontent.com/github/gitignore/master/VisualStudio.gitignore >> .gitignore
-curl https://raw.githubusercontent.com/github/gitignore/master/Global/VisualStudioCode.gitignore >> .gitignore
+# append common git ignores to our default .gitignore
+echo "Building initial .gitignore"
+append_gitignore "Global/JetBrains.gitignore"
+append_gitignore "VisualStudio.gitignore"
+append_gitignore "Global/VisualStudioCode.gitignore"
 
 echo "Creating README.md"
+export NETSTANDARD_VERSION
 process_template "$JCD_NEW_TEMPLATES/classlib/README.md.template" "./README.md"
 
-echo "Creating PULL_REQUEST_TEMPLATE.md"
-process_template "$JCD_NEW_TEMPLATES/PULL_REQUEST_TEMPLATE.md.template" "./PULL_REQUEST_TEMPLATE.md"
-
-echo "Creating CONTRIBUTING.md"
-process_template "$JCD_NEW_TEMPLATES/CONTRIBUTING.md.template" "./CONTRIBUTING.md"
-
-echo "Creating CODE_OF_CONDUCT.md"
-process_template "$JCD_NEW_TEMPLATES/CODE_OF_CONDUCT.md.template" "./CODE_OF_CONDUCT.md"
-
-echo "Creating .github/FUNDING.yml"
-process_template "$JCD_NEW_TEMPLATES/.github/FUNDING.yml.template" ".github/FUNDING.yml"
-
-echo "Creating .github/ISSUE_TEMPLATE/feature_request.md"
-process_template "$JCD_NEW_TEMPLATES/.github/ISSUE_TEMPLATE/feature_request.md.template" ".github/ISSUE_TEMPLATE/feature_request.md"
-
-echo "Creating .github/ISSUE_TEMPLATE/bug_report.md"
-process_template "$JCD_NEW_TEMPLATES/.github/ISSUE_TEMPLATE/bug_report.md.template" ".github/ISSUE_TEMPLATE/bug_report.md"
-
-echo "Creating .github/ISSUE_TEMPLATE/technical_task.md"
-process_template "$JCD_NEW_TEMPLATES/.github/ISSUE_TEMPLATE/technical_task.md.template" ".github/ISSUE_TEMPLATE/technical_task.md"
-
-echo "Creating .github/ISSUE_TEMPLATE/user_story.md"
-process_template "$JCD_NEW_TEMPLATES/.github/ISSUE_TEMPLATE/user_story.md.template" ".github/ISSUE_TEMPLATE/user_story.md"
+process_dot_github_templates "$JCD_NEW_TEMPLATES"
 
 echo "Creating LICENSE"
 process_template "$JCD_NEW_TEMPLATES/LICENSE.template" "./LICENSE"
 
-#TODO: create a template nuget.config and use that instead.
 dotnet new nugetconfig
 
-dotnet new classlib -o "$PROJECT_NAME" -f netstandard2.1
-dotnet add "$PROJECT_NAME/$PROJECT_NAME.csproj" package Jcd.Validations
-dotnet add "$PROJECT_NAME/$PROJECT_NAME.csproj" package DefaultDocumentation
+create_netstandard21_classlib "$PROJECT_NAME"
 dotnet sln add "$PROJECT_NAME/$PROJECT_NAME.csproj"
 
-dotnet new xunit -o "$PROJECT_NAME.Tests"
-dotnet add "$PROJECT_NAME.Tests/$PROJECT_NAME.Tests.csproj" package Moq
-dotnet add "$PROJECT_NAME.Tests/$PROJECT_NAME.Tests.csproj" reference "$PROJECT_NAME/$PROJECT_NAME.csproj"
+create_xunit_tests "$PROJECT_NAME"
 dotnet sln add "$PROJECT_NAME.Tests/$PROJECT_NAME.Tests.csproj"
 
-dotnet new console -o "$PROJECT_NAME.Examples"
-dotnet add "$PROJECT_NAME.Examples/$PROJECT_NAME.Examples.csproj" reference "$PROJECT_NAME/$PROJECT_NAME.csproj"
+create_examples_project "$PROJECT_NAME"
 dotnet sln add "$PROJECT_NAME.Examples/$PROJECT_NAME.Examples.csproj"
 
-#Set netstandard version. Add README.md, nuget.config and LICENSE to library .csproj file
+# Set netstandard version. Add README.md, nuget.config and LICENSE to library .csproj file
+
+# Yes, this is currently an ugly hack. The command line tools don't allow for setting the netstandard version
+# and adding non-project folder non-compilable files wasn't as straight forward as the documentation seemed.
+# Since both required editing the project file I decided to do both at once with this simple
+# set of sed scripts. Yes. I'll need to eventually find a better way. Maybe I'll make a dotnet tool
+# that edits the project file in a simpler to use fashion and allows for changing the netstandard
+# down to 1.0.
 sed -i "s/<TargetFramework>netstandard2.1<\/TargetFramework>/<TargetFramework>netstandard$NETSTANDARD_VERSION<\/TargetFramework>\n    <LangVersion>8<\/LangVersion>/" "$PROJECT_NAME/$PROJECT_NAME.csproj"
 sed -i 's/<\/Project>//' "$PROJECT_NAME/$PROJECT_NAME.csproj"
 echo "

--- a/src/.jcd-new/jcd-new-classlib
+++ b/src/.jcd-new/jcd-new-classlib
@@ -64,7 +64,8 @@ abort_on_missing_gh
 abort_on_missing_dotnet
 
 # capture some data
-export YEAR=$(date +'%Y')
+YEAR=$(date +'%Y')
+export YEAR
 
 pushd "$github"
 

--- a/src/.jcd-new/jcd-new-classlib
+++ b/src/.jcd-new/jcd-new-classlib
@@ -85,8 +85,8 @@ append_gitignore "Global/JetBrains.gitignore"
 append_gitignore "VisualStudio.gitignore"
 append_gitignore "Global/VisualStudioCode.gitignore"
 
-echo "Creating README.md"
 export NETSTANDARD_VERSION
+echo "Creating README.md"
 process_template "$JCD_NEW_TEMPLATES/classlib/README.md.template" "./README.md"
 
 process_dot_github_templates "$JCD_NEW_TEMPLATES"
@@ -106,54 +106,7 @@ create_examples_project "$PROJECT_NAME"
 dotnet sln add "$PROJECT_NAME.Examples/$PROJECT_NAME.Examples.csproj"
 
 # Set netstandard version. Add README.md, nuget.config and LICENSE to library .csproj file
-
-# Yes, this is currently an ugly hack. The command line tools don't allow for setting the netstandard version
-# and adding non-project folder non-compilable files wasn't as straight forward as the documentation seemed.
-# Since both required editing the project file I decided to do both at once with this simple
-# set of sed scripts. Yes. I'll need to eventually find a better way. Maybe I'll make a dotnet tool
-# that edits the project file in a simpler to use fashion and allows for changing the netstandard
-# down to 1.0.
-sed -i "s/<TargetFramework>netstandard2.1<\/TargetFramework>/<TargetFramework>netstandard$NETSTANDARD_VERSION<\/TargetFramework>\n    <LangVersion>8<\/LangVersion>/" "$PROJECT_NAME/$PROJECT_NAME.csproj"
-sed -i 's/<\/Project>//' "$PROJECT_NAME/$PROJECT_NAME.csproj"
-echo "
-    <PropertyGroup>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Title>$PROJECT_NAME</Title>
-        <Authors>$FULL_NAME</Authors>
-        <Description>A short description goes here.</Description>
-        <Copyright>$YEAR</Copyright>
-        <PackageProjectUrl>https://github.com/$GITHUB_USER_NAME/$PROJECT_NAME</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/$GITHUB_USER_NAME/$PROJECT_NAME/blob/main/LICENSE</PackageLicenseUrl>
-        <RepositoryUrl>https://github.com/$GITHUB_USER_NAME/$PROJECT_NAME</RepositoryUrl>
-        <RepositoryType>GitHub</RepositoryType>
-        <PackageVersion>0.0.1</PackageVersion>
-        <AssemblyVersion>0.0.1</AssemblyVersion>
-        <FileVersion>0.0.1</FileVersion>
-        <TargetFramework>netstandard$NETSTANDARD_VERSION</TargetFramework>
-        <PackageIconUrl>https://s.gravatar.com/avatar/c7e8df18f543ea857ac93660a190df98?s=320</PackageIconUrl>
-        <PackageReleaseNotes></PackageReleaseNotes>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <PackageReadmeFile>README.md</PackageReadmeFile>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <None Include=\"..\\README.md\" Pack=\"true\" PackagePath=\"\\\" />
-      <None Include=\"..\\LICENSE\" Pack=\"false\" PackagePath=\"\\\" />
-      <None Include=\"..\\nuget.config\" Pack=\"false\" PackagePath=\"\\\" />
-    </ItemGroup>
-
-    <PropertyGroup Condition=\" '\$(Configuration)' == 'Debug' \">
-      <DocumentationFile>..\\docs\\$PROJECT_NAME.xml</DocumentationFile>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=\" '\$(Configuration)' == 'Release' \">
-      <DocumentationFile>..\\docs\\$PROJECT_NAME.xml</DocumentationFile>
-    </PropertyGroup>
-
-</Project>
-" >> "$PROJECT_NAME/$PROJECT_NAME.csproj"
+set_netstandard_version_and_connect_project_README_and_LICENSE_files
 
 pushd "$PROJECT_NAME"
 
@@ -169,6 +122,7 @@ echo "Performing initial build of $PROJECT_NAME to generate documentation stub."
 dotnet build
 
 git add .
+git add --renormalize .
 git commit -m ".NET Standard $NETSTANDARD_VERSION project created with jcd-new classlib"
 
 echo "Setting main branch name"

--- a/src/.jcd-new/jcd-new.bashlib
+++ b/src/.jcd-new/jcd-new.bashlib
@@ -134,9 +134,9 @@ abort_on_missing_variable() {
   if [ -z ${!VAR_NAME+x} ]
   then
       if [[ "$MESSAGE" == "" ]]; then
-        echo "ABORTING: \\\$$VAR_NAME was not specified in the environment and is required."
+        echo "ABORTING: \$$VAR_NAME was not specified in the environment and is required."
       elif [[ "${EMIT_PREFIX,,}" == true ]]; then
-        echo "ABORTING: \\\$$VAR_NAME not specified in the environment. $MESSAGE"
+        echo "ABORTING: \$$VAR_NAME not specified in the environment. $MESSAGE"
       else
         echo "$MESSAGE"
       fi
@@ -171,9 +171,9 @@ warn_on_missing_variable() {
   if [ -z ${!VAR_NAME+x} ]
   then
       if [[ "$MESSAGE" == "" ]]; then
-        echo "WARNING: \\\$$VAR_NAME was not specified in the environment."
+        echo "WARNING: \$$VAR_NAME was not specified in the environment."
       elif [[ "${EMIT_PREFIX,,}" == true ]]; then
-        echo "WARNING: \\\$$VAR_NAME not specified in the environment. $MESSAGE"
+        echo "WARNING: \$$VAR_NAME not specified in the environment. $MESSAGE"
       else
         echo "$MESSAGE"
       fi

--- a/src/.jcd-new/jcd-new.bashlib
+++ b/src/.jcd-new/jcd-new.bashlib
@@ -297,6 +297,18 @@ Setting main branch name to 'main'"
 
 }
 
+create_github_repo_and_push(){
+  echo "Creating the github repository and pushing."
+  abort_on_missing_variable GITHUB_USER_NAME
+  abort_on_missing_variable PROJECT_NAME
+
+  # Create the github repo and do the initial push
+  gh auth login --hostname github.com || true
+  gh repo create "$GITHUB_USER_NAME/$PROJECT_NAME" --public --gitignore= --license= -y || true
+  git remote add origin "https://github.com/$GITHUB_USER_NAME/$PROJECT_NAME.git"
+  git push -u origin main || true
+}
+
 export -f process_template
 export -f process_dot_github_templates
 export -f init_git
@@ -313,3 +325,4 @@ export -f abort_on_missing_gh
 export -f set_netstandard_version_and_connect_project_README_and_LICENSE_files
 export -f perform_initial_commit_and_set_branch_name_to_main
 export -f abort_on_missing_or_empty_variable
+export -f create_github_repo_and_push

--- a/src/.jcd-new/jcd-new.bashlib
+++ b/src/.jcd-new/jcd-new.bashlib
@@ -182,10 +182,10 @@ warn_on_missing_variable() {
 
 validate_netstandard_version() {
   NETSTANDARD_VERSION="$1"
-  if [ -z ${NETSTANDARD_VERSION+x} ]
+  if [[ "$NETSTANDARD_VERSION" == "" ]]
   then
       echo ".NET Standard version not specified."
-      export NETSTANDARD_VERSION=2.1
+      NETSTANDARD_VERSION=2.1
   fi
 
   if [[ "$NETSTANDARD_VERSION" != @(1[.]0|1[.]1|1[.]2|1[.]3|1[.]4|1[.]5|1[.]6|2[.]0|2[.]1) ]]
@@ -195,6 +195,7 @@ validate_netstandard_version() {
   else
     echo "Using .NET Standard $NETSTANDARD_VERSION"
   fi
+  export NETSTANDARD_VERSION
 }
 
 abort_on_missing_dotnet(){

--- a/src/.jcd-new/jcd-new.bashlib
+++ b/src/.jcd-new/jcd-new.bashlib
@@ -144,6 +144,24 @@ abort_on_missing_variable() {
   fi
 }
 
+abort_on_missing_or_empty_variable() {
+  VAR_NAME="$1"
+  MESSAGE="$2"
+  EMIT_PREFIX="$3"
+  abort_on_missing_variable "$VAR_NAME" "$MESSAGE" "$EMIT_PREFIX"
+  # Perform parameter expansion to detect if the named parameter has been defined.
+  # https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
+  if [[ "${!VAR_NAME+x}" == "" ]]
+  then
+      if [[ "$MESSAGE" == "" ]]; then
+        echo "ABORTING: \\\$$VAR_NAME is empty but is required to contain data."
+      else
+        echo "$MESSAGE"
+      fi
+      exit 1
+  fi
+}
+
 warn_on_missing_variable() {
   VAR_NAME="$1"
   MESSAGE="$2"
@@ -258,6 +276,27 @@ set_netstandard_version_and_connect_project_README_and_LICENSE_files() {
 
 }
 
+perform_initial_commit_and_set_branch_name_to_main() {
+  COMMIT_MESSAGE="$1"
+  abort_on_missing_or_empty_variable COMMIT_MESSAGE "ABORTING: Unable to perform initial commit. Missing a commit message when calling 'perform_initial_commit_and_set_branch_name_to_main'. The calling script is broken."
+  echo "
+Adding files to git"
+  git add .
+
+  echo "
+Normalizing line endings."
+  git add --renormalize .
+
+  echo "
+Performing initial commit."
+  git commit -m "$COMMIT_MESSAGE"
+
+  echo "
+Setting main branch name to 'main'"
+  git branch -M main
+
+}
+
 export -f process_template
 export -f process_dot_github_templates
 export -f init_git
@@ -272,3 +311,5 @@ export -f validate_netstandard_version
 export -f abort_on_missing_dotnet
 export -f abort_on_missing_gh
 export -f set_netstandard_version_and_connect_project_README_and_LICENSE_files
+export -f perform_initial_commit_and_set_branch_name_to_main
+export -f abort_on_missing_or_empty_variable

--- a/src/.jcd-new/jcd-new.bashlib
+++ b/src/.jcd-new/jcd-new.bashlib
@@ -190,6 +190,74 @@ abort_on_missing_gh() {
   gh_ver=$(gh --version)
   echo "gh version $gh_ver detected."
 }
+
+set_netstandard_version_and_connect_project_README_and_LICENSE_files() {
+  # Yes, this is currently an ugly hack. The dotnet command line tools don't allow for setting the netstandard version
+  # and adding non-project folder non-compilable files wasn't as straight forward as the documentation seemed.
+  # Since both required editing the project file I decided to do both at once with this simple
+  # set of sed scripts. Yes. I'll need to eventually find a better way. Maybe I'll make a dotnet tool
+  # that edits the project file in a simpler to use fashion and allows for changing the netstandard
+  # down to 1.0.
+  local ABORT_PREFIX="FROM set_netstandard_version_and_connect_project_README_and_LICENSE_files --"
+
+  abort_on_missing_variable PROJECT_NAME "$ABORT_PREFIX Cannot edit project when none is specified." true
+  abort_on_missing_variable NETSTANDARD_VERSION "$ABORT_PREFIX Cannot edit project when missing NETSTANDARD_VERSION." true
+  abort_on_missing_variable GITHUB_USER_NAME "$ABORT_PREFIX Cannot edit project when missing GITHUB_USER_NAME." true
+  abort_on_missing_variable NETSTANDARD_VERSION "$ABORT_PREFIX Cannot edit project when missing NETSTANDARD_VERSION." true
+  warn_on_missing_variable NUGET_PACKAGE_ICON_URL "No package icon will be used." true
+
+  echo "Setting netstandard to version $NETSTANDARD_VERSION and C# language version to 8"
+  sed -i "s/<TargetFramework>netstandard2.1<\/TargetFramework>/<TargetFramework>netstandard$NETSTANDARD_VERSION<\/TargetFramework>\n    <LangVersion>8<\/LangVersion>/" "$PROJECT_NAME/$PROJECT_NAME.csproj"
+
+  echo "Editing $PROJECT_NAME/$PROJECT_NAME.csproj to:"
+  echo "  * Contain nuget package build information.
+  * Turn on nuget package creation on build
+  * Link, README.md, LICENSE, and nuget.config
+  * Use README.md as the nuget PackageReadmeFile
+  "
+  sed -i 's/<\/Project>//' "$PROJECT_NAME/$PROJECT_NAME.csproj"
+  echo "
+      <PropertyGroup>
+          <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+          <Title>$PROJECT_NAME</Title>
+          <Authors>$FULL_NAME</Authors>
+          <Description>A short description goes here.</Description>
+          <Copyright>$YEAR</Copyright>
+          <PackageProjectUrl>https://github.com/$GITHUB_USER_NAME/$PROJECT_NAME</PackageProjectUrl>
+          <PackageLicenseUrl>https://github.com/$GITHUB_USER_NAME/$PROJECT_NAME/blob/main/LICENSE</PackageLicenseUrl>
+          <RepositoryUrl>https://github.com/$GITHUB_USER_NAME/$PROJECT_NAME</RepositoryUrl>
+          <RepositoryType>GitHub</RepositoryType>
+          <PackageVersion>0.0.1</PackageVersion>
+          <AssemblyVersion>0.0.1</AssemblyVersion>
+          <FileVersion>0.0.1</FileVersion>
+          <TargetFramework>netstandard$NETSTANDARD_VERSION</TargetFramework>
+          <PackageIconUrl>$NUGET_PACKAGE_ICON_URL</PackageIconUrl>
+          <PackageReleaseNotes></PackageReleaseNotes>
+      </PropertyGroup>
+
+      <PropertyGroup>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <None Include=\"..\\README.md\" Pack=\"true\" PackagePath=\"\\\" />
+        <None Include=\"..\\LICENSE\" Pack=\"false\" PackagePath=\"\\\" />
+        <None Include=\"..\\nuget.config\" Pack=\"false\" PackagePath=\"\\\" />
+      </ItemGroup>
+
+      <PropertyGroup Condition=\" '\$(Configuration)' == 'Debug' \">
+        <DocumentationFile>..\\docs\\$PROJECT_NAME.xml</DocumentationFile>
+      </PropertyGroup>
+
+      <PropertyGroup Condition=\" '\$(Configuration)' == 'Release' \">
+        <DocumentationFile>..\\docs\\$PROJECT_NAME.xml</DocumentationFile>
+      </PropertyGroup>
+
+  </Project>
+  " >> "$PROJECT_NAME/$PROJECT_NAME.csproj"
+
+}
+
 export -f process_template
 export -f process_dot_github_templates
 export -f init_git
@@ -203,3 +271,4 @@ export -f warn_on_missing_variable
 export -f validate_netstandard_version
 export -f abort_on_missing_dotnet
 export -f abort_on_missing_gh
+export -f set_netstandard_version_and_connect_project_README_and_LICENSE_files

--- a/src/.jcd-new/jcd-new.bashlib
+++ b/src/.jcd-new/jcd-new.bashlib
@@ -1,5 +1,5 @@
 #!/bin/bash
-# TODO: put reusable functions here and export them
+
 process_template() {
   local template_file="$1"
   local output_file="$2"
@@ -50,8 +50,156 @@ process_template() {
     sed "s/{PATREON_ID}/$PATREON_ID/g" | \
     sed "s/{KOFI_ID}/$KOFI_ID/g" | \
     sed "s/{YEAR}/$YEAR/g" | \
-    sed "s/{FULL_NAME}/$FULL_NAME/g" \
+    sed "s/{FULL_NAME}/$FULL_NAME/g" | \
+    sed "s/[.]template//g" \
     > "$output_file"
 }
 
-export process_template
+process_dot_github_templates() {
+  local JCD_NEW_TEMPLATES="$1"
+  echo "Creating PULL_REQUEST_TEMPLATE.md"
+  process_template "$JCD_NEW_TEMPLATES/PULL_REQUEST_TEMPLATE.md.template" "./PULL_REQUEST_TEMPLATE.md"
+
+  echo "Creating CONTRIBUTING.md"
+  process_template "$JCD_NEW_TEMPLATES/CONTRIBUTING.md.template" "./CONTRIBUTING.md"
+
+  echo "Creating CODE_OF_CONDUCT.md"
+  process_template "$JCD_NEW_TEMPLATES/CODE_OF_CONDUCT.md.template" "./CODE_OF_CONDUCT.md"
+
+  echo "Creating .github/FUNDING.yml"
+  process_template "$JCD_NEW_TEMPLATES/.github/FUNDING.yml.template" ".github/FUNDING.yml"
+
+  echo "Creating .github/ISSUE_TEMPLATE/feature_request.md"
+  process_template "$JCD_NEW_TEMPLATES/.github/ISSUE_TEMPLATE/feature_request.md.template" ".github/ISSUE_TEMPLATE/feature_request.md"
+
+  echo "Creating .github/ISSUE_TEMPLATE/bug_report.md"
+  process_template "$JCD_NEW_TEMPLATES/.github/ISSUE_TEMPLATE/bug_report.md.template" ".github/ISSUE_TEMPLATE/bug_report.md"
+
+  echo "Creating .github/ISSUE_TEMPLATE/technical_task.md"
+  process_template "$JCD_NEW_TEMPLATES/.github/ISSUE_TEMPLATE/technical_task.md.template" ".github/ISSUE_TEMPLATE/technical_task.md"
+
+  echo "Creating .github/ISSUE_TEMPLATE/user_story.md"
+  process_template "$JCD_NEW_TEMPLATES/.github/ISSUE_TEMPLATE/user_story.md.template" ".github/ISSUE_TEMPLATE/user_story.md"
+}
+
+init_git() {
+  echo "Initializing git repository"
+  git init
+
+  echo "Adding empty .gitignore"
+  touch .gitignore
+}
+
+append_gitignore(){
+  local GI_ROOT="https://raw.githubusercontent.com/github/gitignore/master"
+  echo "appending $1 to .gitignore from $GI_ROOT"
+  curl "$GI_ROOT/$1" >> .gitignore
+}
+
+# create an empty solution file
+create_sln(){
+  local SLN_NAME="$1"
+  echo Creating solution "$SLN_NAME"
+  dotnet new sln -o "$SLN_NAME"
+}
+
+# create a netstandard2.1 classlib, with no fix-ups in the csproj file.
+create_netstandard21_classlib() {
+  local PROJECT_NAME="$1"
+  dotnet new classlib -o "$PROJECT_NAME" -f netstandard2.1
+  dotnet add "$PROJECT_NAME/$PROJECT_NAME.csproj" package Jcd.Validations
+  dotnet add "$PROJECT_NAME/$PROJECT_NAME.csproj" package DefaultDocumentation
+}
+
+#create the xunit test project and have it reference the classlib
+create_xunit_tests() {
+  local PROJECT_NAME="$1"
+  dotnet new xunit -o "$PROJECT_NAME.Tests"
+  dotnet add "$PROJECT_NAME.Tests/$PROJECT_NAME.Tests.csproj" package Moq
+  dotnet add "$PROJECT_NAME.Tests/$PROJECT_NAME.Tests.csproj" reference "$PROJECT_NAME/$PROJECT_NAME.csproj"
+}
+
+create_examples_project() {
+  local PROJECT_NAME="$1"
+  dotnet new console -o "$PROJECT_NAME.Examples"
+  dotnet add "$PROJECT_NAME.Examples/$PROJECT_NAME.Examples.csproj" reference "$PROJECT_NAME/$PROJECT_NAME.csproj"
+}
+
+abort_on_missing_variable() {
+  VAR_NAME="$1"
+  MESSAGE="$2"
+  EMIT_PREFIX="$3"
+  # Perform parameter expansion to detect if the named parameter has been defined.
+  # https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
+  if [ -z ${!VAR_NAME+x} ]
+  then
+      if [[ "$MESSAGE" == "" ]]; then
+        echo "ABORTING: \\\$$VAR_NAME was not specified in the environment and is required."
+      elif [[ "${EMIT_PREFIX,,}" == true ]]; then
+        echo "ABORTING: \\\$$VAR_NAME not specified in the environment. $MESSAGE"
+      else
+        echo "$MESSAGE"
+      fi
+      exit 1
+  fi
+}
+
+warn_on_missing_variable() {
+  VAR_NAME="$1"
+  MESSAGE="$2"
+  EMIT_PREFIX="$3"
+  # Perform parameter expansion to detect if the named parameter has been defined.
+  # https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
+  if [ -z ${!VAR_NAME+x} ]
+  then
+      if [[ "$MESSAGE" == "" ]]; then
+        echo "WARNING: \\\$$VAR_NAME was not specified in the environment."
+      elif [[ "${EMIT_PREFIX,,}" == true ]]; then
+        echo "WARNING: \\\$$VAR_NAME not specified in the environment. $MESSAGE"
+      else
+        echo "$MESSAGE"
+      fi
+  fi
+}
+
+validate_netstandard_version() {
+  NETSTANDARD_VERSION="$1"
+  if [ -z ${NETSTANDARD_VERSION+x} ]
+  then
+      echo ".NET Standard version not specified."
+      export NETSTANDARD_VERSION=2.1
+  fi
+
+  if [[ "$NETSTANDARD_VERSION" != @(1[.]0|1[.]1|1[.]2|1[.]3|1[.]4|1[.]5|1[.]6|2[.]0|2[.]1) ]]
+  then
+    echo "$NETSTANDARD_VERSION is not a recognized/supported version of .NET Standard."
+    exit 1
+  else
+    echo "Using .NET Standard $NETSTANDARD_VERSION"
+  fi
+}
+
+abort_on_missing_dotnet(){
+  # validate that the dotnet command line is installed
+  dotnet_ver=$(dotnet --version)
+  echo "dotnet version $dotnet_ver detected."
+}
+
+abort_on_missing_gh() {
+  # validate that the gh tool is installed
+  gh_ver=$(gh --version)
+  echo "gh version $gh_ver detected."
+}
+export -f process_template
+export -f process_dot_github_templates
+export -f init_git
+export -f append_gitignore
+export -f create_sln
+export -f create_netstandard21_classlib
+export -f create_xunit_tests
+export -f create_examples_project
+export -f abort_on_missing_variable
+export -f warn_on_missing_variable
+export -f validate_netstandard_version
+export -f abort_on_missing_dotnet
+export -f abort_on_missing_gh

--- a/src/.jcd-new/jcd-new.bashlib
+++ b/src/.jcd-new/jcd-new.bashlib
@@ -3,7 +3,8 @@
 process_template() {
   local template_file="$1"
   local output_file="$2"
-  local out_dir=$(dirname "$output_file")
+  local out_dir
+  out_dir="$(dirname "$output_file")"
 
   # check if we need to put defaults in for any of the params.
   if [ -z ${PROJECT_NAME+x} ]

--- a/src/.jcd-new/templates/PULL_REQUEST_TEMPLATE.md.template
+++ b/src/.jcd-new/templates/PULL_REQUEST_TEMPLATE.md.template
@@ -1,5 +1,3 @@
-# Pull Request Template
-
 ## Description
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
@@ -24,8 +22,8 @@ list any relevant details for your test configuration
 - [ ] Test A
 - [ ] Test B
 
-**Test Configuration**:
-* Firmware version:
+### Test Configuration
+* OS:
 * Hardware:
 * Toolchain:
 * SDK:

--- a/src/.jcd-new/templates/classlib/README.md.template
+++ b/src/.jcd-new/templates/classlib/README.md.template
@@ -24,17 +24,17 @@ A *.NET Standard {NETSTANDARD_VERSION}* library that provides **a description of
   * Select {PROJECT_NAME} from the list.
   * Click "Import" at the bottom of the screen.
 4. Review various generated non-code files to ensure you have customized the content to this project's
-   needs. *The list is relative to the project root directory.*
-  * ./github/ISSUE_TEMPLATE/bug_report.md
-  * ./github/ISSUE_TEMPLATE/feature_request.md
-  * ./github/ISSUE_TEMPLATE/technical_task.md
-  * ./github/ISSUE_TEMPLATE/user_story.md
-  * ./github/FUNDING.yml - Remove this if you don't want to solicit funding for your works. (Currently only has Patreon and Ko-Fi entries)
-  * ./LICENSE
-  * ./CODE_OF_CONDUCT.md
-  * ./CONTRIBUTING.md
-  * ./PULL_REQUEST.md
-5. Delete this section of the this file and replace it with something meaningful.
+   needs. *The list is relative to the repository root directory.*
+  * [.github/ISSUE_TEMPLATE/bug_report.md](.github/ISSUE_TEMPLATE/bug_report.md)
+  * [.github/ISSUE_TEMPLATE/feature_request.md](.github/ISSUE_TEMPLATE/feature_request.md)
+  * [.github/ISSUE_TEMPLATE/technical_task.md](.github/ISSUE_TEMPLATE/technical_task.md)
+  * [.github/ISSUE_TEMPLATE/user_story.md](.github/ISSUE_TEMPLATE/user_story.md)
+  * [.github/FUNDING.yml](.github/FUNDING.yml) - Remove this if you don't want to solicit funding for your works. (Currently only has Patreon and Ko-Fi entries)
+  * [LICENSE](LICENSE)
+  * [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+  * [CONTRIBUTING.md](CONTRIBUTING.md)
+  * [PULL_REQUEST_TEMPLATE.md](PULL_REQUEST_TEMPLATE.md)
+5. Delete this section of this file and replace it with something meaningful.
 
 ## Examples
 


### PR DESCRIPTION
## Description

Refactored portions of `jcd-new-classlib` functionality into shared library functions.

Fixes #21 

## Type of change

- [X] Technical task. (non-breaking change which adds no new functionality)

## How Has This Been Tested?
Executed the app on Windows 10, git-bash and Debian 11 (WSL2)

- [X] `jcd-new classlib -p=Jcd.Delete.Me`  *expected and got success w/ push to GitHub*
- [X] `jcd-new classlib -ngh -p=Jcd.Delete.Me`  *expected and got success w/o push to GitHub*
- [X] `jcd-new classlib -ngh -p=Jcd.Delete.Me -nsv=1.0`  *expected and got success w/o push to GitHub*
- [X] `jcd-new classlib -ngh -p=Jcd.Delete.Me -nsv=10.0` *expected and got failure related to netstandard version.*
- [X] On Debian 11 executed `jcd-new classlib -ngh -p=Jcd.Delete.Me`  w/o `dotnet` installed and got the expected error message
- [X] On Debian 11 executed `jcd-new classlib -ngh -p=Jcd.Delete.Me`  w/o `gh` installed and got the expected error message
- [X] After successful executions, manually examined the output to ensure the templates were processed correctly.

**Test Configuration**:
* OS(s): Windows 10, Debian 11
* Shell: git-bash, bash

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
