### PR TITLE
Removed dependence on GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ You must have the following environment variables defined:
 
 * $GITHUB_USER_NAME - is required for generating the correct documentation from various template files.
 
-* $GITHUB_TOKEN - is required for the gh tool to push code to GitHub.
-
 * $FULL_NAME - is required for generating the correct documentation from various template files.
 
 ## Optional, But Useful, Environment Variables 
@@ -91,6 +89,12 @@ While you don't need to have the following environment variables defined, they c
 * $PROJECT_EMAIL - This is the email address where you want people to contact you at regarding this project.
   If it's not provided the following will be used: project.email@not.a.real.domain.org; edit CODE_OF_CONDUCT.md
   to remove references to it if you do not want people to contact you via email for the project.
+* $NUGET_PACKAGE_ICON_URL - This is the URL to the image that will be used when packaging the nuget package. If it's 
+  not provided the default nuget icon will be used.
+
+## Optional, Deprecated, Environment Variable
+
+* $GITHUB_TOKEN - this will be used, if present, but issue a warning about it being a security risk.
 
 ## Setting your environment variables
 First off, yes, I know, passing the GITHUB_TOKEN in an environment variable isn't secure.
@@ -101,18 +105,16 @@ First off, yes, I know, passing the GITHUB_TOKEN in an environment variable isn'
 To set the non-sensitive environment variables edit your ~/.bash_profile and add them in a 
 manner similar to the script below.
 ```bash
-export github=~/Source/your--personal-github-folder # I keep mine separate from others' for personal edification. 
+export github=~/Source/your-personal-github-folder # I keep mine separate from others' for personal edification. 
 export FULL_NAME="Your Full Name" # or at least how you want it to appear in the LICENSE file.
 export GITHUB_USER_NAME=your-github-name
 export KOFI_ID=yourkofiname
 export PATREON_ID=yourpatreonname
 export PROJECT_EMAIL=your.oss.email@some.email.com
+export NUGET_PACKAGE_ICON_URL="https://some.imagehost.com/image-url-goes-here"
 ```
 
 Of course, you could set them every time before you run these scripts, but that would be... odd.
-
-For your GITHUB_TOKEN, you can research secrets managers use those to launch these scripts, 
-and have it set only for the duration of their run. They're not cheap tho. 
 
 ## Advice for the first time you run jcd-new.
 

--- a/src/.jcd-new/jcd-new-classlib
+++ b/src/.jcd-new/jcd-new-classlib
@@ -55,7 +55,7 @@ if [ ! -d "$github" ]; then
   exit 1;
 fi
 
-abort_on_missing_variable GITHUB_TOKEN
+warn_on_variable_set GITHUB_TOKEN "Using a token in your environment is a security risk. Please remove it, then login to gh-cli from the command line when prompted." true
 
 abort_on_missing_variable GITHUB_USER_NAME
 

--- a/src/.jcd-new/jcd-new.bashlib
+++ b/src/.jcd-new/jcd-new.bashlib
@@ -174,7 +174,25 @@ warn_on_missing_variable() {
       if [[ "$MESSAGE" == "" ]]; then
         echo "WARNING: \$$VAR_NAME was not specified in the environment."
       elif [[ "${EMIT_PREFIX,,}" == true ]]; then
-        echo "WARNING: \$$VAR_NAME not specified in the environment. $MESSAGE"
+        echo "WARNING: \$$VAR_NAME was not specified in the environment. $MESSAGE"
+      else
+        echo "$MESSAGE"
+      fi
+  fi
+}
+
+warn_on_variable_set() {
+  VAR_NAME="$1"
+  MESSAGE="$2"
+  EMIT_PREFIX="$3"
+  # Perform parameter expansion to detect if the named parameter has been defined.
+  # https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
+  # shellcheck disable=SC2236
+  if [ ! -z ${!VAR_NAME+x} ]; then
+      if [[ "$MESSAGE" == "" ]]; then
+        echo "WARNING: \$$VAR_NAME was specified in the environment."
+      elif [[ "${EMIT_PREFIX,,}" == true ]]; then
+        echo "WARNING: \$$VAR_NAME was specified in the environment. $MESSAGE"
       else
         echo "$MESSAGE"
       fi
@@ -328,3 +346,4 @@ export -f set_netstandard_version_and_connect_project_README_and_LICENSE_files
 export -f perform_initial_commit_and_set_branch_name_to_main
 export -f abort_on_missing_or_empty_variable
 export -f create_github_repo_and_push
+export -f warn_on_variable_set


### PR DESCRIPTION

## Description
- Removed dependence on GITHUB_TOKEN
- Updated project README.md to reflect the deprecation of GITHUB_TOKEN

Fixes #2 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

- [X] With GITHUB_TOKEN defined, executed `jcd-new classlib -p=Jcd.Delete.Me` and verified that it proceeds with the expected warning.
- [X] Without GITHUB_TOKEN defined, executed `jcd-new classlib -p=Jcd.Delete.Me` and verified that it proceeds and relies on the gh cli to prompt for login.


**Test Configuration**:
* OS: Windows 10, Debian 11 (WSL2)
* Shell: git-bash, bash

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
